### PR TITLE
chore(ci): use meza ubuntu slim runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - name: "⬇️ Checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Replace `runs-on: self-hosted` with `runs-on: meza-ubuntu-slim` in 1 GitHub Actions workflow file.

## Validation

- Verified 1 exact runner-label replacement.
- Verified no other staged lines changed.
- `git diff --check` passes.